### PR TITLE
Fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  extends: "standard",
+  env: {
+    es6: true,
+    node: true,
+    mocha: true,
+  },
+  plugins: [
+    "promise"
+  ],
+  rules: {
+    no-tabs: off,
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - stable
-install:
-  - npm install
+  - '8'
+  - '6'

--- a/example.js
+++ b/example.js
@@ -1,62 +1,50 @@
-var imageCache = require('./image-cache');
-var path = require('path');
+var imageCache = require('./image-cache')
+var path = require('path')
 
 imageCache.setOptions({
-	dir: path.join(__dirname, 'cache/'),
-	compressed: false
-});
+  dir: path.join(__dirname, 'cache/'),
+  compressed: false
+})
 
 var images = [
-	"https://4.bp.blogspot.com/-QcLPmwZh-VI/WU5rEVtx9WI/AAAAAAAAfWo/Rs9IBKIuqbc94LlWVjoXNSM_HN-6dQpdgCLcBGAs/s400/%255BHorribleSubs%255D%2BYu-Gi-Oh%2521%2BVRAINS%2B-%2B07%2B720p-muxed_001_1409.png",
-	"https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&url=https://lh3.googleusercontent.com/-AUpXPK4IOi4/AAAAAAAAAAI/AAAAAAAAAAA/AI6yGXxcuACwUIVtH8VfdOlCD8KQjDDZSw/s32-c-mo/photo.jpg"
-];
-var image = "https://4.bp.blogspot.com/-QcLPmwZh-VI/WU5rEVtx9WI/AAAAAAAAfWo/Rs9IBKIuqbc94LlWVjoXNSM_HN-6dQpdgCLcBGAs/s400/%255BHorribleSubs%255D%2BYu-Gi-Oh%2521%2BVRAINS%2B-%2B07%2B720p-muxed_001_1409.png";
+  'https://4.bp.blogspot.com/-QcLPmwZh-VI/WU5rEVtx9WI/AAAAAAAAfWo/Rs9IBKIuqbc94LlWVjoXNSM_HN-6dQpdgCLcBGAs/s400/%255BHorribleSubs%255D%2BYu-Gi-Oh%2521%2BVRAINS%2B-%2B07%2B720p-muxed_001_1409.png',
+  'https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&url=https://lh3.googleusercontent.com/-AUpXPK4IOi4/AAAAAAAAAAI/AAAAAAAAAAA/AI6yGXxcuACwUIVtH8VfdOlCD8KQjDDZSw/s32-c-mo/photo.jpg'
+]
+var image = 'https://4.bp.blogspot.com/-QcLPmwZh-VI/WU5rEVtx9WI/AAAAAAAAfWo/Rs9IBKIuqbc94LlWVjoXNSM_HN-6dQpdgCLcBGAs/s400/%255BHorribleSubs%255D%2BYu-Gi-Oh%2521%2BVRAINS%2B-%2B07%2B720p-muxed_001_1409.png'
 
 // Async
-imageCache.isCached(image, function(exists) {
-
-	if (exists) {
-		imageCache.getCache(image, function(error, result) {
-			console.log(result.hashFile);
-		});
-	} else {
-		imageCache.setCache(image, function(error) {
-			if (error) {
-				console.log(error);
-			} else {
-				console.log("cache ok");
-			}
-		});
-	}
-});
-imageCache.fetchImage(image).then((results) => {
-	console.log(results);
-});
-imageCache.flushCache(function(error, results) {
-	if (error) {
-		console.log(error);
-	} else {
-		console.log(results);
-	}
-});
-
+imageCache.isCached(image, function (exists) {
+  if (exists) {
+    imageCache.get(image, function (error, result) {
+      if (error) throw error
+      console.log(result.hashFile)
+    })
+  }
+})
+imageCache.fetch(image).then((results) => {
+  console.log(results)
+})
+imageCache.fetch(images).then((results) => {
+  console.log(results)
+})
+imageCache.flush(function (error, results) {
+  if (error) {
+    console.log(error)
+  } else {
+    console.log(results)
+  }
+})
 
 // Sync
-var isCached = imageCache.isCachedSync(image);
+var isCached = imageCache.isCachedSync(image)
 
 if (isCached) {
-	let imageData = imageCache.getCacheSync(image);
+  let imageData = imageCache.getSync(image)
 
-	console.log(imageData.url);
-} else {
-	imageCache.setCache(image, function(error) {
-		if (!error) {
-			console.log("cache complete");
-		}
-	});
+  console.log(imageData.url)
 }
 try {
-	imageCache.flushCacheSync();
-} catch(error) {
-	console.log(error);
+  imageCache.flushSync()
+} catch (error) {
+  console.log(error)
 }

--- a/image-cache.js
+++ b/image-cache.js
@@ -1,244 +1,231 @@
-const Core = require('./lib/core');
-const _ = require('underscore');
-const path = require('path');
-const fs = require('fs');
+const Core = require('./lib/core')
+const _ = require('underscore')
+const path = require('path')
+const fs = require('fs')
 
 /**
  * image-cache - Image Cache Async with Base64
- * @author Ryan Aunur Rassyid <Indonesia><ryandevstudio@gmail.com> 
+ * @author Ryan Aunur Rassyid <Indonesia><ryandevstudio@gmail.com>
  */
 
 /** imageCache class
  * @description imageCache extends from Core
  */
-class imageCache extends Core {
-	compress() {
-		this.inlineCompress = true;
+class ImageCache extends Core {
+  compress () {
+    this.inlineCompress = true
 
-		return this;
-	}
-	/** isCached
+    return this
+  }
+  /** isCached
 	 * @description Async function check is image on argument available on cache
 	 *
 	 * @param {String}
 	 * @param {Function}
 	 * @return Promise
 	 */
-	isCached(image, callback) {
-		if (_.isFunction(callback)) {
+  isCached (image, callback) {
+    if (_.isFunction(callback)) {
+      this.isCachedService(image, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.isCachedService(image, function (err, exists) {
+          if (err) reject(err)
 
-			this.isCachedService(image, callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.isCachedService(image, function(err, exists) {
-					if (err) reject(err);
-
-					resolve(exists);
-				});
-			});
-		}
-	}
-	/** isCachedSync
+          resolve(exists)
+        })
+      })
+    }
+  }
+  /** isCachedSync
 	 * @description check is image available on cached / already cached?
-	 * 
-	 * @param {String} image 
+	 *
+	 * @param {String} image
 	 * @return {Boolean}
 	 */
-	isCachedSync(image) {
-		try	{
-			fs.statSync(this.getFilePath(image));
-		} catch(e) {
-			if (this.equal(e.code, 'ENOENT')) {
-				return false;
-			}
-		}
+  isCachedSync (image) {
+    try	{
+      fs.statSync(this.getFilePath(image))
+    } catch (e) {
+      if (this.equal(e.code, 'ENOENT')) {
+        return false
+      }
+    }
 
-		return true;
-	}
+    return true
+  }
 
-	/** get() ASYNC
-	 * @description Get cached image from folder using same url 
+  /** get() ASYNC
+	 * @description Get cached image from folder using same url
 	 *
 	 * @param {String|Array} image
 	 * @return {Callback|Promise}
 	 */
-	get(image, callback) {
-		if (_.isFunction(callback)) {
+  get (image, callback) {
+    if (_.isFunction(callback)) {
+      this.getCacheService(image, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.getCacheService(image, function (err, results) {
+          if (err) reject(err)
 
-			this.getCacheService(image, callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.getCacheService(image, function(err, results) {
-					if (err) reject(err);
-
-					resolve(results);
-				});
-			});
-		}
-	};
-	/** getSync() SYNC
+          resolve(results)
+        })
+      })
+    }
+  };
+  /** getSync() SYNC
 	 * @description get image from cache
-	 * 
-	 * @param {String|Array} 	image 
+	 *
+	 * @param {String|Array} 	image
 	 * @return {Callback|Promise}
 	 */
-	getSync(image) {
-		try	{
-			return this.readFileSync(image);
-		} catch(e) {
-			return e;
-		}
-	}
+  getSync (image) {
+    try	{
+      return this.readFileSync(image)
+    } catch (e) {
+      return e
+    }
+  }
 
-	/** store() ASYNC
-	 * @description store image as a cache 
+  /** store() ASYNC
+	 * @description store image as a cache
 	 *
-	 * @param {String|Array} images 
-	 * @return {Function|Promise} 
+	 * @param {String|Array} images
+	 * @return {Function|Promise}
 	 */
-	store(images, callback) {
-		if (_.isFunction(callback)) {
+  store (images, callback) {
+    if (_.isFunction(callback)) {
+      this.storeCacheService(images, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.storeCacheService(images, function (err, results) {
+          if (err) reject(err)
 
-			this.storeCacheService(images, callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.storeCacheService(images, function(err, results) {
-					if (err) reject(err);
+          resolve(results)
+        })
+      })
+    }
+  }
 
-					resolve(results);
-				});
-			});
-		}
-	}
-
-	/**
+  /**
 	 * @description check is image already on cache will be return as cache or is not available
 	 * on cache folder then will be return as image (and cached)
-	 * 
-	 * @param {String|Array} images 
-	 * @param {Function|Promise} callback 
+	 *
+	 * @param {String|Array} images
+	 * @param {Function|Promise} callback
 	 */
-	fetch(images, callback) {
-		if (_.isFunction(callback)) {
+  fetch (images, callback) {
+    if (_.isFunction(callback)) {
+      this.fetchImagesService(images, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.fetchImagesService(images, function (err, results) {
+          if (err) reject(err)
 
-			this.fetchImagesService(images, callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.fetchImagesService(images, function(err, results) {
-					if (err) reject(err);
+          resolve(results)
+        })
+      })
+    }
+  }
 
-					resolve(results);
-				});
-			});
-		}
-	}
-
-	/**
+  /**
 	 * @description remove image from cache folder
-	 * 
-	 * @param {Array|String} images 
+	 *
+	 * @param {Array|String} images
 	 */
-	remove(images) {
-		if (_.isFunction(callback)) {
+  remove (images, callback) {
+    if (_.isFunction(callback)) {
+      this.removeCacheService(images, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.removeCacheService(images, function (err, results) {
+          if (err) reject(err)
 
-			this.removeCacheService(images, callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.removeCacheService(images, function(err, results) {
-					if (err) reject(err);
+          resolve(results)
+        })
+      })
+    }
+  }
 
-					resolve(results);
-				});
-			});
-		}
-	}
-
-	/**
+  /**
 	 * @description remove all cached image on Cache Directory
-	 * 
+	 *
 	 */
-	flush() {
-		if (_.isFunction(callback)) {
+  flush (callback) {
+    if (_.isFunction(callback)) {
+      this.flushCacheService(callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.flushCacheService(function (err, results) {
+          if (err) reject(err)
 
-			this.flushCacheService(callback);
-		} else {
-			
-			return new Promise((resolve, reject) => {
-				this.flushCacheService(function(err, results) {
-					if (err) reject(err);
-
-					resolve(results);
-				});
-			});
-		}
-	}
-	/**
+          resolve(results)
+        })
+      })
+    }
+  }
+  /**
 	 * @description remove all cached image on Cache Directory Syncronius function
-	 * 
+	 *
 	 */
-	flushSync() {
-		var files = fs.readdirSync(this.options.dir);
-		var deletedFiles = 0;
+  flushSync () {
+    var files = fs.readdirSync(this.options.dir)
+    var deletedFiles = 0
 
-		if (this.equal(files.length, 0)) {
-			throw new Error({
-				message: `ERR_EMPTY: ${this.options.dir} is empty folder`,
-				code: `ERR_EMPTY`
-			});
-		} else {
-			for (let $index in files) {
-				let file = files[$index];
+    if (this.equal(files.length, 0)) {
+      throw new Error({
+        message: `ERR_EMPTY: ${this.options.dir} is empty folder`,
+        code: `ERR_EMPTY`
+      })
+    } else {
+      for (let $index in files) {
+        let file = files[$index]
 
-				if (this.equal(path.extname(file), this.options.extname)) {
-					try {
-						fs.unlinkSync(path.join(this.options.dir, file));
-					} catch (e) {
-						throw new Error(e);
-					} finally {
-						deletedFiles++;
-					}
-				}
-			}
+        if (this.equal(path.extname(file), this.options.extname)) {
+          try {
+            fs.unlinkSync(path.join(this.options.dir, file))
+          } catch (e) {
+            throw new Error(e)
+          } finally {
+            deletedFiles++
+          }
+        }
+      }
 
-			return {
-				error: false,
-				deleted: deletedFiles,
-				totalFiles: files.length,
-				dir: options.dir
-			}
-		}
-	}
+      return {
+        error: false,
+        deleted: deletedFiles,
+        totalFiles: files.length,
+        dir: this.options.dir
+      }
+    }
+  }
 
-	on(event, callback) {
-		switch(event) {
-			case 'get':
-				if (_.isFunction(callback)) this.eventProvider.onGet = callback;
-				break;
-			case 'set':
-				if (_.isFunction(callback)) this.eventProvider.onSet = callback;
-				break;
-			case 'fetch':
-				if (_.isFunction(callback)) this.eventProvider.onFetch = callback;
-				break;
-			case 'remove':
-				if (_.isFunction(callback)) this.eventProvider.onRemove = callback;
-				break;
-			case 'flush':
-				if (_.isFunction(callback)) this.eventProvider.onFlush = callback;
-				break;
-			default:
-				throw new Error({
-					message: `ERR_EVENT: undefined event name '${event}'`,
-					code: `ERR_EVENT`
-				});
-				break;
-		}
-	}
+  on (event, callback) {
+    switch (event) {
+      case 'get':
+        if (_.isFunction(callback)) this.eventProvider.onGet = callback
+        break
+      case 'set':
+        if (_.isFunction(callback)) this.eventProvider.onSet = callback
+        break
+      case 'fetch':
+        if (_.isFunction(callback)) this.eventProvider.onFetch = callback
+        break
+      case 'remove':
+        if (_.isFunction(callback)) this.eventProvider.onRemove = callback
+        break
+      case 'flush':
+        if (_.isFunction(callback)) this.eventProvider.onFlush = callback
+        break
+      default:
+        throw new Error({
+          message: `ERR_EVENT: undefined event name '${event}'`,
+          code: `ERR_EVENT`
+        })
+    }
+  }
 }
 
-module.exports = new imageCache;
+module.exports = new ImageCache()

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,558 +1,552 @@
-const base64Img = require('base64-img');
-const _ 		= require('underscore');
-const async 	= require("async");
-const path 		= require('path');
-const pako 		= require('pako'); 
-const md5 		= require("md5");
-const fs 		= require('fs');
+const base64Img = require('base64-img')
+const _ 		= require('underscore')
+const async 	= require('async')
+const path 		= require('path')
+const pako 		= require('pako')
+const md5 		= require('md5')
+const fs 		= require('fs')
 
 /** Core class
  * imageCache Core function
  */
 module.exports = class Core {
-	constructor(args) {
-		this.eventProvider = {
-			onGet: function() {},
-			onSet: function() {},
-			onRemove: function() {},
-			onFlush: function() {},
-			onFetch: function() {},
-			onError: function() {}
-		}
-		this.inlineCompress = false;
-		this.options = {
-			dir: path.join(__dirname, "cache/"),
-			compressed: false,
-			extname: '.cache',
-			googleCache: true
-		};
-	}
+  constructor (args) {
+    this.eventProvider = {
+      onGet: function () {},
+      onSet: function () {},
+      onRemove: function () {},
+      onFlush: function () {},
+      onFetch: function () {},
+      onError: function () {}
+    }
+    this.inlineCompress = false
+    this.options = {
+      dir: path.join(__dirname, 'cache/'),
+      compressed: false,
+      extname: '.cache',
+      googleCache: true
+    }
+  }
 
-	/** Utility
+  /** Utility
 	 * @description list of utility
 	 */
-	equal(a, b) {
-		return (a == b);
-	}
-	/** Check params images to actualiy be Array data type
+  equal (a, b) {
+    return (a === b)
+  }
+  /** Check params images to actualiy be Array data type
 	 * and convert them into Array data
 	 *
-	 * @param	{Array|String} 	images 
+	 * @param	{Array|String} 	images
 	 * @return	{Array}
 	 */
-	isArray(images) {
-		if (!Array.isArray(images)) {
-			let temp = images;
-			images = [temp];
-		}
-		/** Check is cache directory available
+  isArray (images) {
+    if (!Array.isArray(images)) {
+      let temp = images
+      images = [temp]
+    }
+    /** Check is cache directory available
 		 */
-		if (!this.isDirExists()) {
-			fs.mkdirSync(this.options.dir);
-		}
+    if (!this.isDirExists()) {
+      fs.mkdirSync(this.options.dir)
+    }
 
-		return images;
-	}
-	/** isDirExists 
+    return images
+  }
+  /** isDirExists
 	 * Synchronius function to check is path on dir options is a Directory
 	 *
 	 * @return Object
 	 */
-	isDirExists() {	
-		try	{
-			fs.statSync(this.options.dir);
-		} catch(e) {
-			return false;
-		}
+  isDirExists () {
+    try	{
+      fs.statSync(this.options.dir)
+    } catch (e) {
+      return false
+    }
 
-		return true;
-	}
-	isFileExist(pathFile) {
-		try	{
-			fs.statSync(pathFile);
-		} catch(e) {
-			return false;
-		}
+    return true
+  }
+  isFileExist (pathFile) {
+    try	{
+      fs.statSync(pathFile)
+    } catch (e) {
+      return false
+    }
 
-		return true;
-	}
-	/** getFilePath
+    return true
+  }
+  /** getFilePath
 	 * @description Syncronius function to get file path after joining dir, filename, and extention options
 	 *
 	 * @param  {String} 	image
 	 * @return {String}
 	 */
-	getFilePath(image) {
-		var fileName = (this.options.compressed) ? `${md5(image)}_min` : md5(image);
+  getFilePath (image) {
+    var fileName = (this.options.compressed) ? `${md5(image)}_min` : md5(image)
 
-		return this.options.dir + fileName + this.options.extname;
-	}
-	/** getImages
+    return this.options.dir + fileName + this.options.extname
+  }
+  /** getImages
 	 * @description Async function to get every images with base64 format
 	 *
 	 * @param  {Array} 		images
 	 * @param  {Function} 	callback
 	 * @return {Callback} 	(error, results)	Boolean, Object
 	 */
-	getImages(images, callback) {
-		let fetch = (url, callback) => {
-			var tempUri = url;
-			if (this.options.googleCache) {
-				url = this.getGoogleUrl(url);
-			}
+  getImages (images, callback) {
+    let fetch = (url, callback) => {
+      var tempUri = url
+      if (this.options.googleCache) {
+        url = this.getGoogleUrl(url)
+      }
 
-			base64Img.requestBase64(url, (error, res, body) => {
-				if (error) {
-					callback(error);
-				} else {
-					if (this.equal(res.statusCode.toString(), "200")) {
-						callback(null, {
-							error: false,
-							url: tempUri,
-							timestamp: new Date().getTime(),
-							hashFile: md5(tempUri),
-							compressed: this.options.compressed,
-							data: body
-						});
-					} else {
-						callback(true, {
-							error: true,
-							url: tempUri,
-							statusCode: res.statusCode,
-							statusMessage: res.statusMessage
-						});
-					}
-				}
-			});	
-		}
-		async.map(images, fetch, (error, results) => {
-			if (error) {
-				callback(error);
-			} else {
-				callback(null, results);
-			}
-		});
-	}
-	/** stringToTime
+      base64Img.requestBase64(url, (error, res, body) => {
+        if (error) {
+          callback(error)
+        } else {
+          if (this.equal(res.statusCode.toString(), '200')) {
+            callback(null, {
+              error: false,
+              url: tempUri,
+              timestamp: new Date().getTime(),
+              hashFile: md5(tempUri),
+              compressed: this.options.compressed,
+              data: body
+            })
+          } else {
+            callback(new Error(`Error fething image: ${res.statusCode} - ${res.statusMessage}`), {
+              error: true,
+              url: tempUri,
+              statusCode: res.statusCode,
+              statusMessage: res.statusMessage
+            })
+          }
+        }
+      })
+    }
+    async.map(images, fetch, (error, results) => {
+      if (error) {
+        callback(error)
+      } else {
+        callback(null, results)
+      }
+    })
+  }
+  /** stringToTime
 	 * @description convert string to time, for example 1w => 604800
-	 * 
+	 *
 	 * @param {String} 		time
 	 * @return {Integer} 		second
 	 */
-	stringToTime(time) {
-		let weeks = time.toLowerCase().match(/([\d]+)w/);
-		let days = time.toLowerCase().match(/([\d]+)d/);
-		let hours = time.toLowerCase().match(/([\d]+)h/);
-		let minutes = time.toLowerCase().match(/([\d]+)m/);
-	
-		if (weeks) {
-			return weeks[1] * 7 * 24 * 60 * 60;
-		} else if (days) {
-			return days[1] * 24 * 60 * 60;
-		} else if (hours) {
-			return hours[1] * 60 * 60;
-		} else if (minutes) {
-			return minutes[1] * 60;
-		}
-	}
-	/** getGoogleUrl
-	 * @description Sync function get joined url 
+  stringToTime (time) {
+    let weeks = time.toLowerCase().match(/([\d]+)w/)
+    let days = time.toLowerCase().match(/([\d]+)d/)
+    let hours = time.toLowerCase().match(/([\d]+)h/)
+    let minutes = time.toLowerCase().match(/([\d]+)m/)
+
+    if (weeks) {
+      return weeks[1] * 7 * 24 * 60 * 60
+    } else if (days) {
+      return days[1] * 24 * 60 * 60
+    } else if (hours) {
+      return hours[1] * 60 * 60
+    } else if (minutes) {
+      return minutes[1] * 60
+    }
+  }
+  /** getGoogleUrl
+	 * @description Sync function get joined url
 	 *
-	 * @param {String} 	url 
+	 * @param {String} 	url
 	 * @return {String}
 	 */
-	getGoogleUrl(url, options) {
-		let urls = 'https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy'
-					+ '?container=focus'
-					+ '&url=' + url
-					;
-		
-		if (_.isObject(options)) {
-			if (!_.isNull(options.width)) urls += `&resize_w=${options.width}`;
-			if (!_.isNull(options.refresh)) urls += `&refresh=${options.refresh}`;
-		}
+  getGoogleUrl (url, options) {
+    let urls = 'https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy' +
+					'?container=focus' +
+					'&url=' + url
 
-		return urls;
-	}
-	/** unlinkCache
+    if (_.isObject(options)) {
+      if (!_.isNull(options.width)) urls += `&resize_w=${options.width}`
+      if (!_.isNull(options.refresh)) urls += `&refresh=${options.refresh}`
+    }
+
+    return urls
+  }
+  /** unlinkCache
 	 * @description Sync function remove cache file using `fs`
-	 * @param {Function} 	callback 
+	 * @param {Function} 	callback
 	 * @return Type
 	 */
-	unlinkCache(callback) {
-		try	{
-			fs.unlinkSync(path);
-		} catch(e) {
-			callback(e);
-		}
+  unlinkCache (callback) {
+    try	{
+      fs.unlinkSync(path)
+    } catch (e) {
+      callback(e)
+    }
 
-		callback(null);
-	}
-	/**
+    callback(null)
+  }
+  /**
 	 * @description convert Buffer into String
-	 * @param {Buffer} content 
+	 * @param {Buffer} content
 	 */
-	backToString(content) {
-		if (Buffer.isBuffer(content)) content = content.toString('utf8');
-		content = content.replace(/^\uFEFF/, '');
-		
-		return content;
-	}
-	/**
-	 * @description set size of file 
-	 * 
-	 * @param {String} path 
-	 * @param {String} image 
+  backToString (content) {
+    if (Buffer.isBuffer(content)) content = content.toString('utf8')
+    content = content.replace(/^\uFEFF/, '')
+
+    return content
+  }
+  /**
+	 * @description set size of file
+	 *
+	 * @param {String} path
+	 * @param {String} image
 	 */
-	setSize(path, image) {
-		var type = typeof image;
+  setSize (path, image) {
+    var type = typeof image
 
-		return new Promise((resolve, reject) => {
-			fs.stat(path, (error, file) => {
-				if (file.isFile()) {
-					if (this.equal(type, "string")) image = JSON.parse(image);
+    return new Promise((resolve, reject) => {
+      fs.stat(path, (error, file) => {
+        if (error) reject(error)
+        if (file.isFile()) {
+          if (this.equal(type, 'string')) image = JSON.parse(image)
 
-					image.size = this.toSize(file.size, true);
+          image.size = this.toSize(file.size, true)
 
-					if (this.equal(type, "string")) image = JSON.stringify(image);
-					resolve(image);
-				} else {
-					reject(path.basename(path) + " is not a file");
-				}
-			});         
-		});
-	}
-	/**
+          if (this.equal(type, 'string')) image = JSON.stringify(image)
+          resolve(image)
+        } else {
+          reject(new Error(path.basename(path) + ' is not a file'))
+        }
+      })
+    })
+  }
+  /**
 	 * @description read file from cached file
-	 * 
-	 * @param {Object} params 
-	 * @param {Function} callback 
+	 *
+	 * @param {Object} params
+	 * @param {Function} callback
 	 */
-	readFileFetch(params, callback) {
-		fs.readFile(params.path, (err, cachedImage) => {
-			if (!err) {
-				cachedImage = this.inflate(this.backToString(cachedImage));
-				
-				cachedImage.cache = "HIT";
+  readFileFetch (params, callback) {
+    fs.readFile(params.path, (err, cachedImage) => {
+      if (!err) {
+        cachedImage = this.inflate(this.backToString(cachedImage))
 
-				this.setSize(params.path, cachedImage).then((result) => {
-					callback(null, result);
-				}).catch((error) => {
-					callback(error);
-				});
-				
-			} else {
-				callback(err);
-			}
-		});
-	}
-	/**
+        cachedImage.cache = 'HIT'
+
+        this.setSize(params.path, cachedImage).then((result) => {
+          callback(null, result)
+        }).catch((error) => {
+          callback(error)
+        })
+      } else {
+        callback(err)
+      }
+    })
+  }
+  /**
 	 * @description write cache file
-	 * 
-	 * @param {Object} params 
-	 * @param {Function} callback 
+	 *
+	 * @param {Object} params
+	 * @param {Function} callback
 	 */
-	writeFileFetch(params, callback) {
-		this.writeFile({
-			data: params.data,
-			fileName: params.source.hashFile
-		}, (error) => {
-			if (error) {
-				callback(error);
-			} else {
-				/** set Miss Cache
+  writeFileFetch (params, callback) {
+    this.writeFile({
+      data: params.data,
+      fileName: params.source.hashFile
+    }, (error) => {
+      if (error) {
+        callback(error)
+      } else {
+        /** set Miss Cache
 				 */
-				params.source.cache = "MISS";
-				callback(null, params.source);
-			}
-		});
-	}
-	/**
+        params.source.cache = 'MISS'
+        callback(null, params.source)
+      }
+    })
+  }
+  /**
 	 * @description compress file if compress options is true
-	 * 
-	 * @param {Object} data 
+	 *
+	 * @param {Object} data
 	 */
-	deflate(data) {
-		let result;
-		if (this.options.compressed) {
-			result = pako.deflate(JSON.stringify(data), { to: 'string' });
-		} else {
-			result = JSON.stringify(data);
-		}
+  deflate (data) {
+    let result
+    if (this.options.compressed) {
+      result = pako.deflate(JSON.stringify(data), { to: 'string' })
+    } else {
+      result = JSON.stringify(data)
+    }
 
-		return result;
-	}
-	/**
+    return result
+  }
+  /**
 	 * @description decompress file if file is compressed
-	 * 
-	 * @param {String} cachedImage 
+	 *
+	 * @param {String} cachedImage
 	 */
-	inflate(cachedImage) {
-		if (this.options.compressed) {
-			cachedImage = pako.inflate(cachedImage, { to: 'string' });
-		}
+  inflate (cachedImage) {
+    if (this.options.compressed) {
+      cachedImage = pako.inflate(cachedImage, { to: 'string' })
+    }
 
-		return JSON.parse(cachedImage);
-	}
-	/**
+    return JSON.parse(cachedImage)
+  }
+  /**
 	 * @description read file as async function
-	 * 
-	 * @param {*} image 
-	 * @param {*} callback 
+	 *
+	 * @param {*} image
+	 * @param {*} callback
 	 */
-	readFile(image, callback) {
-		var path = this.getFilePath(image);
-		fs.readFile(path, (error, results) => {
-			if (error) {
-				callback(error);
-			} else {
-				results = this.backToString(results);
+  readFile (image, callback) {
+    var path = this.getFilePath(image)
+    fs.readFile(path, (error, results) => {
+      if (error) {
+        callback(error)
+      } else {
+        results = this.backToString(results)
 
-				this.setSize(path, results).then((result) => {
-					callback(null, result);
-				}).catch((error) => {
-					callback(error);
-				});
-			}
-		});
-	}
-	readFileSync(image) {
-		let path = this.getFilePath(image);
-		let results = this.backToString(fs.readFileSync(path));
+        this.setSize(path, results).then((result) => {
+          callback(null, result)
+        }).catch((error) => {
+          callback(error)
+        })
+      }
+    })
+  }
+  readFileSync (image) {
+    let path = this.getFilePath(image)
+    let results = this.backToString(fs.readFileSync(path))
 
-		let stats = this.isFileExist(path);
-		
-		if (stats.isFile()) {
-			results = JSON.parse(results);
-			results.size = this.toSize(stats.size, true);
-			
-			return results;
-		} else {
-			throw new Error({
-				message: `ERR_FILE: ${path} is not a file`,
-				code: `ERR_FILE`
-			});
-		}
-	}
-	writeFile(params, callback) {
-		fs.writeFile(path.join(this.options.dir, `${params.fileName} ${this.options.extname}`), params.data, (error) => {
-			callback(error);
-		});
-	}
-	fetchImage(image, callback) {
-		if (image.exists) {
-			this.readFileFetch({
-				path: this.getFilePath(image.fileName)
-			}, (error, result) => {
-				if (error) {
-					callback(error);
-				} else {
-					callback(null, result);
-				}
-			});
-		} else {
-			this.getImages([ image.url ], (error, results) => {
-				if (error) {
-					callback(error);
-				} else {
-					results.forEach((result) => {
-						if (!result.error) {
-							this.writeFileFetch({
-								source: result,
-								data: this.deflate(result)
-							}, (error) => {
-								if (error) {
-									callback(error);
-								} else {
-									callback(null, result);
-								}
-							});
-						}
-					});
-				}
-			});
-		}
-	}
-	toSize(size, read) {
-		var thresh = read ? 1000 : 1024;
-		if(Math.abs(size) < thresh) {
-			return size + ' B';
-		}
-		var units = read
-			? ['kB','MB','GB','TB','PB','EB','ZB','YB']
-			: ['KiB','MiB','GiB','TiB','PiB','EiB','ZiB','YiB'];
-		var u = -1;
-		do {
-			size /= thresh;
-			++u;
-		} while(Math.abs(size) >= thresh && u < units.length - 1);
+    let stats = this.isFileExist(path)
 
-		return size.toFixed(1)+' '+units[u];
-	}
+    if (stats.isFile()) {
+      results = JSON.parse(results)
+      results.size = this.toSize(stats.size, true)
 
-	setOptions(options) {
+      return results
+    } else {
+      throw new Error({
+        message: `ERR_FILE: ${path} is not a file`,
+        code: `ERR_FILE`
+      })
+    }
+  }
+  writeFile (params, callback) {
+    fs.writeFile(path.join(this.options.dir, `${params.fileName} ${this.options.extname}`), params.data, (error) => {
+      callback(error)
+    })
+  }
+  fetchImage (image, callback) {
+    if (image.exists) {
+      this.readFileFetch({
+        path: this.getFilePath(image.fileName)
+      }, (error, result) => {
+        if (error) {
+          callback(error)
+        } else {
+          callback(null, result)
+        }
+      })
+    } else {
+      this.getImages([ image.url ], (error, results) => {
+        if (error) {
+          callback(error)
+        } else {
+          results.forEach((result) => {
+            if (!result.error) {
+              this.writeFileFetch({
+                source: result,
+                data: this.deflate(result)
+              }, (error) => {
+                if (error) {
+                  callback(error)
+                } else {
+                  callback(null, result)
+                }
+              })
+            }
+          })
+        }
+      })
+    }
+  }
+  toSize (size, read) {
+    var thresh = read ? 1000 : 1024
+    if (Math.abs(size) < thresh) {
+      return size + ' B'
+    }
+    var units = read
+      ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+      : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+    var u = -1
+    do {
+      size /= thresh
+      ++u
+    } while (Math.abs(size) >= thresh && u < units.length - 1)
 
-		this.options = Object.assign(this.options, options);
-	}
+    return size.toFixed(1) + ' ' + units[u]
+  }
 
-	isCachedService(image, callback) {
-		fs.stat(this.getFilePath(image), (err, stats) => { 
-			/** Represented from Object into Boolean
-			 */	
+  setOptions (options) {
+    this.options = Object.assign(this.options, options)
+  }
 
-			if (stats) {
-				callback(null, true);
-			} else {
-				if (this.equal(err.code, "ENOENT")) {
-					callback(null, false);
-				}
-			}
-		});
-	}
-	getCacheService(image, callback) {
-		this.readFile(image, (error, results) => {
-			if (error) {
-				callback(error);
-			} else {
-				callback(null, this.inflate(results));
-			}
+  isCachedService (image, callback) {
+    fs.stat(this.getFilePath(image), (err, stats) => {
+      /** Represented from Object into Boolean
+			 */
 
-			this.eventProvider.onGet({
-				url: image,
-				error: error
-			});
-		});
-	}
-	storeCacheService(images, callback) {
-		this.eventProvider.onSet();
+      if (stats) {
+        callback(null, true)
+      } else {
+        if (this.equal(err.code, 'ENOENT')) {
+          callback(null, false)
+        }
+      }
+    })
+  }
+  getCacheService (image, callback) {
+    this.readFile(image, (error, results) => {
+      if (error) {
+        callback(error)
+      } else {
+        callback(null, this.inflate(results))
+      }
 
-		images = this.isArray(images);
+      this.eventProvider.onGet({
+        url: image,
+        error: error
+      })
+    })
+  }
+  storeCacheService (images, callback) {
+    this.eventProvider.onSet()
 
-		this.getImages(images, (error, results) => {
-			if (!error) {
+    images = this.isArray(images)
 
-				results.forEach((result) => {
-					if (result.error) callback("Error while getting images");
+    this.getImages(images, (error, results) => {
+      if (!error) {
+        results.forEach((result) => {
+          if (result.error) callback(new Error('Error while getting images'))
 
-					this.writeFile({
-						fileName: result.hashFile,
-						data: this.deflate(result)
-					}, (error) => {
-						if (error) {
-							callback("Error while write files " + result.hashFile);
-						} else {
-							callback(null, result);
-						}
-					});
-				});
-			} else {
+          this.writeFile({
+            fileName: result.hashFile,
+            data: this.deflate(result)
+          }, (error) => {
+            if (error) {
+              callback(new Error('Error while write files ' + result.hashFile))
+            } else {
+              callback(null, result)
+            }
+          })
+        })
+      } else {
+        callback(error)
+      }
+    })
+  }
+  removeCacheService (images, callback) {
+    this.eventProvider.onRemove()
 
-				callback(error.message);
-			}
-		});
-	}
-	removeCacheService(images, callback) {
-		this.eventProvider.onRemove();
+    images = this.isArray(images)
 
-		images = this.isArray(images);
+    images.forEach((image) => {
+      try	{
+        fs.unlinkSync(this.getFilePath(image))
+      } catch (e) {
+        callback(e)
+      }
+    })
 
-		images.forEach((image) => {
-			try	{
-				fs.unlinkSync(this.getFilePath(image));
-			} catch(e) {
-				callback(e);
-			}
-		});
-
-		/** Callback onSuccess
+    /** Callback onSuccess
 		 * `images` will be send back into resolve
 		 */
-		callback(null, images);
-	}
-	fetchImagesService(images, callback) {
-		this.eventProvider.onFetch();
+    callback(null, images)
+  }
+  fetchImagesService (images, callback) {
+    this.eventProvider.onFetch()
 
-		images = this.isArray(images);
+    images = this.isArray(images)
 
-		async.waterfall([
-			(callback) => {
-				let imagesMore = [];
+    async.waterfall([
+      (callback) => {
+        let imagesMore = []
 
-				async.each(images, (image, callbackEach) => {
-					let fileName = this.getFilePath(image);
-					let exists = this.isFileExist(fileName);
-					let url = image;
+        async.each(images, (image, callbackEach) => {
+          let fileName = this.getFilePath(image)
+          let exists = this.isFileExist(fileName)
+          let url = image
 
-					imagesMore.push({
-						fileName: image,
-						exists: exists,
-						url: url
-					});
+          imagesMore.push({
+            fileName: image,
+            exists: exists,
+            url: url
+          })
 
-					callbackEach(null);
-				}, (err) => {
-					if (!err) callback(null, imagesMore);
-				});
-			},
-			(imagesMore, callback) => {
-				async.map(imagesMore, this.fetchImage.bind(this), (error, results) => {
-					if (error) {
-						callback(error);
-					} else {
-						if (this.equal(results.length, 1) && Array.isArray(results)) {
-							results = results[0];
-						}
+          callbackEach(null)
+        }, (err) => {
+          if (!err) callback(null, imagesMore)
+        })
+      },
+      (imagesMore, callback) => {
+        async.map(imagesMore, this.fetchImage.bind(this), (error, results) => {
+          if (error) {
+            callback(error)
+          } else {
+            if (this.equal(results.length, 1) && Array.isArray(results)) {
+              results = results[0]
+            }
 
-						callback(null, results);
-					}
-				});
-			}
-		], (error, success) => {
-			if (!error) {
-				callback(null, success);
-			} else {
-				callback(error);
-			}
-		});
-	}
-	flushCacheService(callback) {
-		this.eventProvider.onFlush();
+            callback(null, results)
+          }
+        })
+      }
+    ], (error, success) => {
+      if (!error) {
+        callback(null, success)
+      } else {
+        callback(error)
+      }
+    })
+  }
+  flushCacheService (callback) {
+    this.eventProvider.onFlush()
 
-		fs.readdir(this.options.dir, (error, files) => {
-			var targetFiles = [];
+    fs.readdir(this.options.dir, (error, files) => {
+      if (error) callback(error)
+      var targetFiles = []
 
-			if (this.equal(files.length, 0)) {
-				/**
+      if (this.equal(files.length, 0)) {
+        /**
 				 * Callback error when `folder empty`
 				 * @return Object
 				 */
-				callback({
-					message: `ERR_EMPTY: ${this.options.dir} is empty folder`,
-					code: `ERR_EMPTY`
-				});
-			} else {
-				files.forEach((file) => {
-					if (this.equal(path.extname(file), self.options.extname)) {
-						targetFiles.push(self.options.dir + "/" + file);
-					}
-				});
+        callback(new Error(`ERR_EMPTY: ${this.options.dir} is empty folder`))
+      } else {
+        files.forEach((file) => {
+          if (this.equal(path.extname(file), this.options.extname)) {
+            targetFiles.push(this.options.dir + '/' + file)
+          }
+        })
 
-				async.map(targetFiles, this.unlinkCache, (error, results) => {
-					if (error) {
-						callback(error);
-					} else {
-						/**
+        async.map(targetFiles, this.unlinkCache, (error, results) => {
+          if (error) {
+            callback(error)
+          } else {
+            /**
 						 * Callback onSuccess
 						 * @return Object
 						 */
-						callback(null, {
-							deleted: targetFiles.length,
-							totalFiles: files.length,
-							dir: options.dir
-						});
-					}
-				});
-			}
-		});
-	}
+            callback(null, {
+              deleted: targetFiles.length,
+              totalFiles: files.length,
+              dir: this.options.dir
+            })
+          }
+        })
+      }
+    })
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1658 @@
+{
+  "name": "image-cache",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajax-request": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ajax-request/-/ajax-request-1.2.3.tgz",
+      "integrity": "sha1-mfy+wdbSeS+F+pSVNTMr0U9fN5A=",
+      "requires": {
+        "file-system": "2.2.2",
+        "utils-extend": "1.0.8"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-img": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/base64-img/-/base64-img-1.0.4.tgz",
+      "integrity": "sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=",
+      "requires": {
+        "ajax-request": "1.2.3",
+        "file-system": "2.2.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
+      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.2",
+        "concat-stream": "1.6.1",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.3.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      }
+    },
+    "eslint-config-standard": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "dev": true,
+      "requires": {
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.5.0"
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
+      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "dev": true
+    },
+    "eslint-plugin-standard": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "requires": {
+        "utils-extend": "1.0.8"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "requires": {
+        "file-match": "1.0.2",
+        "utils-extend": "1.0.8"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
+      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "description": "Node JS Image Cache with Base64 Encode",
   "main": "image-cache.js",
   "scripts": {
-    "test": "node node_modules/.bin/mocha test/test.js"
+    "lint": "eslint .",
+    "spec": "node node_modules/.bin/mocha test/test.js",
+    "test": "npm run lint && npm run spec"
+  },
+  "engines": {
+    "node": ">=6.9.0"
   },
   "keywords": [
     "image cache",
@@ -16,18 +21,23 @@
   "author": "Ryan Aunur Rassyid <ryandevstudio@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "async": "^2.4.1",
-    "base64-img": "^1.0.3",
+    "async": "^2.6.0",
+    "base64-img": "^1.0.4",
     "md5": "^2.2.1",
-    "pako": "^1.0.5",
-    "underscore": "^1.8.3",
-    "zlib": "^1.0.5"
+    "pako": "^1.0.6",
+    "underscore": "^1.8.3"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/nyancodeid/image-cache.git"
   },
   "devDependencies": {
-    "mocha": "^3.4.2"
+    "eslint": "^4.18.2",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "mocha": "^5.0.4"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -102,8 +102,4 @@ describe('imageCache Test', function () {
       })
     })
   })
-  // describe('#flush cache', function () {
-  //   it('should be true', () => imageCache.flush()
-  //     .then(result => assert.equal(typeof data, 'object')))
-  // })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,126 +1,109 @@
-/* This test need Internet connection to fetch 
+/* This test need Internet connection to fetch
  * Image file from the Internet
  */
 
-const imageCache = require('../image-cache');
-const Core = require('../lib/core');
-const assert = require('assert');
+const assert = require('assert')
+const path = require('path')
+const imageCache = require('../image-cache')
 
-var url = 'http://webresource.c-ctrip.com/ResCRMOnline/R5/html5/images/57.png';
-var urlYes = "https://lh3.googleusercontent.com/-AUpXPK4IOi4/AAAAAAAAAAI/AAAAAAAAAAA/AI6yGXxcuACwUIVtH8VfdOlCD8KQjDDZSw/s32-c-mo/photo.jpg";
-var urlNone = 'http://webresource.c-ctrip.com/ResCRM/57.png';
+var url = 'http://webresource.c-ctrip.com/ResCRMOnline/R5/html5/images/57.png'
+var urlYes = 'https://lh3.googleusercontent.com/-AUpXPK4IOi4/AAAAAAAAAAI/AAAAAAAAAAA/AI6yGXxcuACwUIVtH8VfdOlCD8KQjDDZSw/s32-c-mo/photo.jpg'
+var urlNone = 'http://webresource.c-ctrip.com/ResCRM/57.png'
 
-describe('imageCache Test', function() {
-	beforeEach(function() {
-		imageCache.setOptions({
-			dir: __dirname + "/images/",
-			compressed: false
-		});
-	});
+describe('imageCache Test', function () {
+  beforeEach(function () {
+    imageCache.setOptions({
+      dir: path.join(__dirname, '/images/'),
+      compressed: false
+    })
+  })
 
-	describe('#Check is file cached', function() {
-		/* isCached with Callback
-		 * test isCached call with async function using callback. 
+  describe('#Check is file cached', function () {
+    /* isCached with Callback
+		 * test isCached call with async function using callback.
 		 *
 		 * @expect Boolean 		false
 		 */
-		it('#isCached() {Callback} should be return false', function(done) {
-			imageCache.isCached(url, function(err, exist) {
-				assert.equal(exist, false);
-
-				done();
-			});
-		});
-		/* isCached with Callback
-		 * test isCached call with async function using Promise. 
+    it('#isCached() {Callback} should be return false', function (done) {
+      imageCache.isCached(url, function (err, exist) {
+        assert.equal(exist, false)
+        done(err)
+      })
+    })
+    /* isCached with Callback
+		 * test isCached call with async function using Promise.
 		 *
 		 * @expect Boolean 		true
 		 */
-		it('#isCached() {Promise} should be return true', function(done) {
-			imageCache.isCached(urlYes).then((exist) => {
-				assert.equal(exist, true);
-
-				done();
-			}).catch((e) => {
-				done();
-			});
-		});
-		/* isCachedSync
-		 * test isCachedSync call with sync function. 
+    it('#isCached() {Promise} should be return true', function () {
+      return imageCache.isCached(urlYes)
+        .then(exist => assert.equal(exist, true))
+    })
+    /* isCachedSync
+		 * test isCachedSync call with sync function.
 		 *
 		 * @expect Boolean 		false
 		 */
-		it('#isCachedSync() {Try} should be return false', function() {
-			var exists = imageCache.isCachedSync(url);
-			
-			assert.equal(exists, false);
-		});
-	});
-	describe('#Get file from cached', function() {
-		it('#get() {Callback} should be return error code ENOENT', function(done) {
-			imageCache.get(url, function(error, result) {
-				assert.equal(error.code, "ENOENT");
+    it('#isCachedSync() {Try} should be return false', function () {
+      var exists = imageCache.isCachedSync(url)
 
-				done();
-			});
-		});
-		it('#get() {Promise} should be return object without error', function(done) {
-			imageCache.get(urlYes).then((result) => {
-				assert.equal(typeof result, "object");
-				assert.equal(result.error, false);
+      assert.equal(exists, false)
+    })
+  })
+  describe('#Get file from cached', function () {
+    it('#get() {Callback} should be return error code ENOENT', function (done) {
+      imageCache.get(url, function (error, result) {
+        assert.equal(error.code, 'ENOENT')
+        done()
+      })
+    })
+    it('#get() {Promise} should be return object without error', function () {
+      return imageCache.get(urlYes)
+        .then((result) => {
+          assert.equal(typeof result, 'object')
+          assert.equal(result.error, false)
+        }).catch((error) => {
+          assert.notEqual(error.code, 'ENOENT')
+        })
+    })
+    it('#getSync() should be return error code ENOENT', function () {
+      var result = imageCache.getSync(url)
 
-				done();
-			}).catch((error) => {
-				assert.notEqual(error.code, "ENOENT");
-
-				done();
-			});
-		});
-		it('#getSync() should be return error code ENOENT', function() {
-			var result = imageCache.getSync(url);
-			
-			assert.equal(result.code, "ENOENT");
-		});
-	});
-	describe('#store a image', function() {
-		it('should be false', function(done) {
-			imageCache.compress().store(urlYes).then((result) => {
-				console.log(result);
-
-				done();
-			}).catch((e) => {
-				
-
-				done();
-			});
-		});
-	});
-	describe('#fetch a image ', function() {
-		it('#fetch() {Callback} should be return false', function(done) {
-			imageCache.fetch(urlNone, (err, result) => {
-				assert.notEqual(err, null);
-
-				done();
-			});
-		});
-		it('#fetch() {Promise} should be return false', function(done) {
-			imageCache.fetch(urlYes).then((result) => {
-				assert.equal(result.error, false);
-
-				done();
-			});
-		});
-	});
-	describe('#event test', function() {
-		it('#onGet event', function(done) {
-			imageCache.on('get', function(data) {
-				assert.equal(typeof data, "object");
-
-				done();
-			});
-			imageCache.get(urlYes).then((result) => {
-				assert.equal(result.error, false);
-			});
-		});
-	});
-});
+      assert.equal(result.code, 'ENOENT')
+    })
+  })
+  describe('#store a image', function () {
+    it('should be false', function () {
+      return imageCache.compress().store(urlYes)
+        .catch(error => assert.notEqual(error.message.indexOf('Error fething image'), -1))
+    })
+  })
+  describe('#fetch a image ', function () {
+    it('#fetch() {Callback} should be return false', function (done) {
+      imageCache.fetch(urlNone, (err, result) => {
+        assert.notEqual(err, null)
+        done()
+      })
+    })
+    it('#fetch() {Promise} should be return false', () => {
+      return imageCache
+        .fetch(urlYes)
+        .then(result => assert.equal(result.error, false))
+    })
+  })
+  describe('#event test', function () {
+    it('#onGet event', function (done) {
+      imageCache.on('get', function (data) {
+        assert.equal(typeof data, 'object')
+        done()
+      })
+      imageCache.get(urlYes).then((result) => {
+        assert.equal(result.error, false)
+      })
+    })
+  })
+  // describe('#flush cache', function () {
+  //   it('should be true', () => imageCache.flush()
+  //     .then(result => assert.equal(typeof data, 'object')))
+  // })
+})


### PR DESCRIPTION
The original code has various references to deprecated functions (`getCache`, `setCache`, etc.) This PR fixes as many of these errors, replacing them with all the new functions (`get`, `set`, etc).
There's another PR #1 that introduces fixes with `eslint` but their configuration is all wrong, and it doesn't address any of the deeper problems the code has.
It also updates some of the dependencies and introduces a requirement for node `>= v6`, the previous code wasn't working with node `v4` anyway.