### PR TITLE
Bug in writeFile filename

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -335,7 +335,7 @@ module.exports = class Core {
 		}
 	}
 	writeFile(params, callback) {
-		fs.writeFile(path.join(this.options.dir, `${params.fileName} ${this.options.extname}`), params.data, (error) => {
+		fs.writeFile(path.join(this.options.dir, `${params.fileName}${this.options.extname}`), params.data, (error) => {
 			callback(error);
 		});
 	}


### PR DESCRIPTION
Has a space when writing out filenames - which isn't used when reading them back in.